### PR TITLE
Optimize Singleton members

### DIFF
--- a/cpp/src/patterns/singleton/Singleton.h
+++ b/cpp/src/patterns/singleton/Singleton.h
@@ -4,9 +4,11 @@
 class Singleton {
 private :
     Singleton();
-    Singleton(Singleton const&);
-    void operator=(Singleton const&);
+
 public :
     static Singleton &GetInstance();
+
+    Singleton(Singleton const&) = delete;
+    Singleton &operator=(Singleton const&) = delete;
 };
 #endif /* SIGLETON_H_ */


### PR DESCRIPTION
Make copy and assignment member function inaccessible in new style;
The assignment function should return a reference.
